### PR TITLE
Add toggles for wrap and light mode

### DIFF
--- a/main.go
+++ b/main.go
@@ -33,13 +33,13 @@ func main() {
 
 func handleRequest(w http.ResponseWriter, r *http.Request) {
 	req, err := http.Get("https://cdn.discordapp.com/attachments" + r.URL.Path)
-	defer req.Body.Close()
-
 	if err != nil {
 		log.Println(err)
 		_, _ = fmt.Fprintln(w, "An error occurred fetching from the discord api")
 		return
 	}
+
+	defer req.Body.Close()
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 

--- a/paste.html
+++ b/paste.html
@@ -1,26 +1,84 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
     <link href="https://fonts.googleapis.com/css?family=JetBrains+Mono&display=swap" rel="preload" as="style" />
     <link href="https://fonts.googleapis.com/css?family=JetBrains+Mono&display=swap" rel="stylesheet" />
     <meta charset="UTF-8">
     <meta name="robots" content="noindex">
-    <meta charset="utf-8" name="viewport" content= "width=device-width, initial-scale=1.0">
+    <meta charset="utf-8" name="viewport" content="width=device-width, initial-scale=1.0">
     <title>MinecraftHopper paste</title>
     <style>
-        body,
         html {
             background: #000;
+        }
+        .paste {
             font-family: "JetBrains Mono", monospace;
             margin-left: 1%;
             margin-right: 1%;
             color: #fff;
-	    word-wrap: break-word;
-	}
+            white-space: nowrap;
+        }
     </style>
 </head>
 
-<body>
-    {{.}}
+<body onload="onLoad()">
+    <div class="options" id="options">
+        Wrap lines <input type="checkbox" id="wrap" onclick="toggleWrap()">
+        Light mode <input type="checkbox" id="color" onclick="toggleColorMode()">
+    </div>
+    <div class="paste" id="paste">{{.}}</div>
 </body>
+<script>
+    function toggleWrap() {
+        if (document.getElementById("wrap").checked === true) {
+            document.getElementById("paste").style.whiteSpace = "break-spaces";
+            localStorage.setItem("wrap", "yes");
+        }
+        else {
+            document.getElementById("paste").style.whiteSpace = "nowrap";
+            localStorage.setItem("wrap", "no");
+        }
+    }
+    function toggleColorMode() {
+        if (document.getElementById("color").checked === true) {
+            document.getElementById("paste").style.color = "#000";
+            document.getElementById("paste").style.backgroundColor = "#fff";
+            document.getElementById("options").style.color = "#000";
+            document.getElementById("options").style.backgroundColor = "#fff";
+            document.documentElement.style.color = "#000";
+            document.documentElement.style.backgroundColor = "#fff";
+            localStorage.setItem("color", "light");
+        }
+        else {
+            document.getElementById("paste").style.color = "#fff";
+            document.getElementById("paste").style.backgroundColor = "#000";
+            document.getElementById("options").style.color = "#fff";
+            document.getElementById("options").style.backgroundColor = "#000";
+            document.documentElement.style.color = "#fff";
+            document.documentElement.style.backgroundColor = "#000";
+            localStorage.setItem("color", "dark");
+        }
+    }
+    function onLoad() {
+        let wrap;
+        let color;
+        console.log(wrap)
+        if (localStorage.getItem("wrap") === "yes") {
+            wrap = true
+        } else {
+            wrap = false
+        }
+        if (localStorage.getItem("color") === "light") {
+            color = true
+        } else {
+            color = false
+        }
+        document.getElementById("wrap").checked = wrap;
+        document.getElementById("color").checked = color;
+        toggleColorMode();
+        toggleWrap();
+    }
+</script>
+
 </html>

--- a/paste.html
+++ b/paste.html
@@ -19,6 +19,10 @@
             color: #fff;
             white-space: nowrap;
         }
+        .options {
+            font-family: "JetBrains Mono", monospace;
+            text-align: center;
+        }
     </style>
 </head>
 


### PR DESCRIPTION
This commit adds toggle checkboxes for light and dark mode and word wrapping. It also saves these settings in localStorage